### PR TITLE
Sweep: change start port to 5188 (✓ Sandbox Passed)

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -33,7 +33,7 @@ await new Promise((resolve, reject) => {
 
 // Configure Cloudflare dev server
 // https://miniflare.dev/get-started/api
-const port = await getPort({ port: portNumbers(8080, 8090) });
+const port = await getPort({ port: 5188 });
 mf = new Miniflare({
   name: edgeConfig.name,
   log: new Log(LogLevel.INFO),

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -2,7 +2,7 @@
 /* SPDX-License-Identifier: MIT */
 
 import { execa } from "execa";
-import getPort, { portNumbers } from "get-port";
+import getPort from "get-port";
 import { debounce } from "lodash-es";
 import { Log, LogLevel, Miniflare } from "miniflare";
 import { getArgs, getCloudflareBindings, readWranglerConfig } from "./utils.js";

--- a/server/start.ts
+++ b/server/start.ts
@@ -4,7 +4,7 @@
 import getPort from "get-port";
 import { listen } from "./index";
 
-const port = await getPort({ port: portNumbers(8080, 9000) });
+const port = await getPort({ port: 5188 });
 
 let dispose = listen(port);
 

--- a/server/start.ts
+++ b/server/start.ts
@@ -1,7 +1,7 @@
 /* SPDX-FileCopyrightText: 2014-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
-import getPort, { portNumbers } from "get-port";
+import getPort from "get-port";
 import { listen } from "./index";
 
 const port = await getPort({ port: portNumbers(8080, 9000) });


### PR DESCRIPTION
# Description
This pull request updates the start port in the scripts/start.js and server/start.ts files to 5188.

# Summary
- Updated start port in `scripts/start.js` from `8080-8090` to `5188`
- Updated start port in `server/start.ts` from `8080-9000` to `5188`

Fixes #10.

---

<details>
<summary><b>🎉 Latest improvements to Sweep:</b></summary>
<ul>
<li>New <a href="https://progress.sweep.dev">dashboard</a> launched for real-time tracking of Sweep issues, covering all stages from search to coding.</li>
<li>Integration of OpenAI's latest Assistant API for more efficient and reliable code planning and editing, improving speed by 3x.</li>
<li>Use the <a href="https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github">GitHub issues extension</a> for creating Sweep issues directly from your editor.</li>
</ul>
</details>


---

### 💡 To get Sweep to edit this pull request, you can:
* Comment below, and Sweep can edit the entire PR
* Comment on a file, Sweep will only modify the commented file
* Edit the original issue to get Sweep to recreate the PR from scratch